### PR TITLE
Fix massageMetadataOutput to handle null metadata values

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -50,7 +50,7 @@ function massageMetadataOutput (metadata) {
   if (metadata) {
     for (let k in metadata) {
       if (!k.startsWith('bin:')) {
-        metadata[k] = metadata[k].toString('utf8')
+        metadata[k] = metadata[k] && metadata[k].toString('utf8')
       }
     }
   }


### PR DESCRIPTION
Not sure why this issue is cropping up in the Hyperspace port, but `massageMetadataOutput` is now handling `null` values (for the `pinned` metadata field), which is breaking the massage function.